### PR TITLE
chore: use pg_last_xlog_replay_location to get replication lag

### DIFF
--- a/bin/check-postgres-replication.rb
+++ b/bin/check-postgres-replication.rb
@@ -113,7 +113,7 @@ class CheckPostgresReplicationStatus < Sensu::Plugin::Check::CLI
                             sslmode: ssl_mode,
                             connect_timeout: config[:timeout])
 
-    slave = conn_slave.exec('SELECT pg_last_xlog_receive_location()').getvalue(0, 0)
+    slave = conn_slave.exec('SELECT pg_last_xlog_replay_location()').getvalue(0, 0)
     conn_slave.close
 
     # Computing lag

--- a/bin/metric-postgres-graphite.rb
+++ b/bin/metric-postgres-graphite.rb
@@ -99,7 +99,7 @@ class CheckpostgresReplicationStatus < Sensu::Plugin::Metric::CLI::Graphite
                             user: config[:user],
                             password: config[:password],
                             connect_timeout: config[:timeout])
-    res = conn_slave.exec('SELECT pg_last_xlog_receive_location()').getvalue(0, 0)
+    res = conn_slave.exec('SELECT pg_last_xlog_replay_location()').getvalue(0, 0)
     conn_slave.close
 
     # Compute lag


### PR DESCRIPTION
## Description
Use pg_last_xlog_replay_location to get the replication lag instead of pg_last_xlog_receive_location. If the replication is paused, with pg_last_xlog_receive_location the effective delay between the replica and the master isn't seen.

For information, bellow a [postgres documentation](https://www.postgresql.org/docs/current/static/functions-admin.html#FUNCTIONS-RECOVERY-INFO-TABLE) extract:
- pg_last_xlog_receive_location() Get last transaction log location received and synced to disk by streaming replication. While streaming replication is in progress this will increase monotonically. If recovery has completed this will remain static at the value of the last WAL record received and synced to disk during recovery. If streaming replication is disabled, or if it has not yet started, the function returns NULL.
- pg_last_xlog_replay_location() Get last transaction log location replayed during recovery. If recovery is still in progress this will increase monotonically. If recovery has completed then this value will remain static at the value of the last WAL record applied during that recovery. When the server has been started normally without recovery the function returns NULL.