### PR TITLE
fix: check postgres replication timeout

### DIFF
--- a/bin/check-postgres-replication.rb
+++ b/bin/check-postgres-replication.rb
@@ -80,7 +80,7 @@ class CheckPostgresReplicationStatus < Sensu::Plugin::Check::CLI
 
   option(:timeout,
          short: '-T',
-         long: '--timeout',
+         long: '--timeout TIMEOUT',
          default: nil,
          description: 'Connection timeout (seconds)')
 


### PR DESCRIPTION
## Description
Fix the connect timeout in check-postgres-replication.rb.
The timeout value was always 'true'. The timeout argument passed to the check wasn't catched.
