### PR TITLE
chore: BUMP sensu plugins postgres to handle different pg versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,81 @@
-#Change Log
+# Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
+This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md).
 
 ## [Unreleased]
+
+## [1.4.5] - 2018-02-15
+### Fixed
+- metric-postgres-graphite.rb: use the custom defined port when connecting to slave (@henkjan)
+
+### Added
+- basic skel for integration testing with postgres (@majormoses)
+- added test for `./bin/check-postgres-alive.rb`
+
+## [1.4.4] - 2017-11-08
+### Fixed
+- check-postgres-replication.rb: fix 9.x compatibility
+
+## [1.4.3] - 2017-11-06
+### Fixed
+- check-postgres-replication.rb: maintains backwards compatibility with <= 9.6 and adds compatibility for >= 10
+
+## [1.4.2] - 2017-09-27
+### Fixed
+- metric-postgres-locks.rb: Fix lock count collection (@madboxkr)
+
+## [1.4.1] - 2017-09-26
+### Fixed
+- metrics-postgres-query.rb: Add a nil check to avoid failure when the query result is empty (@eheydrick)
+- PR template spelling (@majormoses)
+
+### Changed
+- updated CHANGELOG guidelines location (@majormoses)
+
+## [1.4.0] - 2017-08-04
+### Added
+- all checks now support using the pgpass file and is backwards compatible with the previous versions (@ahes)
+
+## [1.3.0] - 2017-07-25
+### Fixed
+- Take into account reserved superuser connections in check-postgres-connections.rb (@Evesy)
+
+### Added
+- Ruby 2.4.1 testing
+
+## [1.2.0] - 2017-07-12
+### Added
+- metric-postgres-statsdb.rb: Adds new metric `numbackends`. (@phumpal)
+
+## [1.1.2] - 2017-06-02
+### Fixed
+- check-postgresq-replication.rb: Adds missing option for custom port.
+
+## [1.1.1] - 2017-04-24
+### Fixed
+- metrics-postgres-query.rb: Restored default value to only return first value in query. (@Micasou)
+
+## [1.1.0] - 2017-04-20
+### Added
+- metrics-postgres-query.rb: Add option to return multi row queries. (@Micasou)
+
+### Fixed
+- check-postgres-alive.rb: Fix connections using a custom port (#25 via @mickfeech)
+- check-postgres-connections.rb: Fix connections using a custom port (#25)
+- check-postgres-query.rb: Fix connections using a custom port (#25)
+- check-postgres-replication.rb: Fix connections using a custom port (#25)
+- metrics-postgres-connections.rb: Fix connections using a custom port (#25)
+- metrics-postgres-dbsize.rb: Fix connections using a custom port (#25)
+- metrics-postgres-graphite.rb: Fix connections using a custom port (#25)
+- metrics-postgres-graphite.rb: Fix connections using password (@teadur)
+- metrics-postgres-locks.rb: Fix connections using a custom port (#25)
+- metrics-postgres-statsgbwriter.rb: Fix connections using a custom port (#25)
+- metrics-postgres-statsdb.rb: Fix connections using a custom port (#25)
+- metrics-postgres-statsio.rb: Fix connections using a custom port (#25)
+- metrics-postgres-statstable.rb: Fix connections using a custom port (#25)
+- metrics-postgres-query.rb: Fix connections using a custom port (#25)
+- check-postgres-connections.rb: Fix logic to check critical first then warning (#24 via @nevins-b)
 
 ## [1.0.1] - 2017-01-04
 ### Fixed
@@ -66,7 +138,18 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Added
 - initial release
 
-[Unreleased]: https://github.com/sensu-plugins/sensu-plugins-postgres/compare/1.0.1...HEAD
+[Unreleased]: https://github.com/sensu-plugins/sensu-plugins-postgres/compare/1.4.5...HEAD
+[1.4.5]: https://github.com/sensu-plugins/sensu-plugins-postgres/compare/1.4.4...1.4.5
+[1.4.4]: https://github.com/sensu-plugins/sensu-plugins-postgres/compare/1.4.3...1.4.4
+[1.4.3]: https://github.com/sensu-plugins/sensu-plugins-postgres/compare/1.4.2...1.4.3
+[1.4.2]: https://github.com/sensu-plugins/sensu-plugins-postgres/compare/1.4.1...1.4.2
+[1.4.1]: https://github.com/sensu-plugins/sensu-plugins-postgres/compare/1.4.0...1.4.1
+[1.4.0]: https://github.com/sensu-plugins/sensu-plugins-postgres/compare/1.3.0...1.4.0
+[1.3.0]: https://github.com/sensu-plugins/sensu-plugins-postgres/compare/1.2.0...1.3.0
+[1.2.0]: https://github.com/sensu-plugins/sensu-plugins-postgres/compare/1.1.2...1.2.0
+[1.1.2]: https://github.com/sensu-plugins/sensu-plugins-postgres/compare/1.1.1...1.1.2
+[1.1.1]: https://github.com/sensu-plugins/sensu-plugins-postgres/compare/1.1.0...1.1.1
+[1.1.0]: https://github.com/sensu-plugins/sensu-plugins-postgres/compare/1.0.1...1.1.0
 [1.0.1]: https://github.com/sensu-plugins/sensu-plugins-postgres/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/sensu-plugins/sensu-plugins-postgres/compare/0.1.1...1.0.0
 [0.1.1]: https://github.com/sensu-plugins/sensu-plugins-postgres/compare/0.1.0...0.1.1

--- a/README.md
+++ b/README.md
@@ -25,8 +25,93 @@
 
 ## Usage
 
+Use `--help` to see command arguments.
+
+### Sample usage
+
+#### Check if PostgreSQL is alive
+```
+$ check-postgres-alive.rb -d template1 -f /var/lib/postgresql/.pgpass
+CheckPostgres OK: Server version: {"version"=>"PostgreSQL 9.6.3 on x86_64-pc-linux-gnu, compiled by gcc (Debian 4.9.2-10) 4.9.2, 64-bit"}
+```
+
+### Check replication status
+```
+$ check-postgres-replication.rb -m psql1.local -s psql2.local -d template1 -w 5 -c 10
+CheckPostgresReplicationStatus OK: replication delayed by 0.0MB :: master:B0/B4031000 slave:B0/B4031000 m_segbytes:16777216
+```
+
+### Check number of connections
+```
+$ export PGPASSWORD=this-is-secret-password
+$ check-postgres-connections.rb -a -w 80 -c 90 -d template1 -u sensu
+CheckPostgresConnections OK: PostgreSQL connections under threshold: 17%, 174 out of 997 connections
+```
+
+### Default values
+
+| Argument       | Env variable | Value     |
+|----------------|--------------|-----------|
+| -f, --pgpass   | PGPASSFILE   | ~/.pgpass |
+| -h, --hostname | PGHOST       | localhost |
+| -P, --port     | PGPORT       | 5432      |
+| -d, --database | PGDATABASE   | postgres  |
+| -u, --user     | PGUSER       | postgres  |
+| -p, --password | PGPASSWORD   |           |
+
+Options precedence is following:
+1. command line arguments
+1. pgpass file
+1. env variables
+1. defaults
+
+### Pgpass file
+
+When file `~/.pgpass` is found it is used by default. You can also use `-f, --pgpass` command line argument or set `PGPASSFILE` env variable.
+
+File format is:
+
+```
+hostname:port:database:username:password
+```
+
+Only first line is used. If database is set to `*` it is ommited.
+
+You can ovveride `pgpass` values with command line arguments, e.g. `-h` for hostname.
+
 ## Installation
 
-[Installation and Setup](http://sensu-plugins.io/docs/installation_instructions.html)
+```
+gem install sensu-plugins-postgres
+```
+
+## Centos installation
+
+```
+yum -y install gcc ruby-devel rubygems  postgresql-devel
+sensu-install -p sensu-plugins-postgres
+
+```
+
+See [Installation and Setup](http://sensu-plugins.io/docs/installation_instructions.html) for details.
+
+### Known issues
+
+When using Sensu with `EMBEDDED_RUBY=true` and installing Postgres checks with `/usr/bin/sensu-install -p sensu-plugins-postgres` you might get following error:
+
+```
+ERROR:  Error installing sensu-plugins-postgres:
+	ERROR: Failed to build gem native extension.
+[...]
+checking for PQconnectdb() in -lpq... no
+checking for PQconnectdb() in -llibpq... no
+checking for PQconnectdb() in -lms/libpq... no
+Can't find the PostgreSQL client library (libpq)
+*** extconf.rb failed ***
+```
+
+The reason is that **libssl** library which comes with Sensu is incompatible with **libpq** library installed on your system. There is no easy way to fix it. You might want to install sensu-plugins-postgres globally with `gem install sensu-plugins-postgres`.
+
+Checks are in `/usr/local/bin` directory.
 
 ## Notes

--- a/Rakefile
+++ b/Rakefile
@@ -5,11 +5,13 @@ require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 require 'yard'
 require 'yard/rake/yardoc_task'
+require 'English'
+require 'kitchen/rake_tasks'
 
 YARD::Rake::YardocTask.new do |t|
-  OTHER_PATHS = %w().freeze
+  OTHER_PATHS = %w[].freeze
   t.files = ['lib/**/*.rb', 'bin/**/*.rb', OTHER_PATHS]
-  t.options = %w(--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md)
+  t.options = %w[--markup-provider=redcarpet --markup=markdown --main=README.md --files CHANGELOG.md]
 end
 
 RuboCop::RakeTask.new
@@ -35,4 +37,10 @@ task :check_binstubs do
   end
 end
 
-task default: [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
+Kitchen::RakeTasks.new
+
+desc 'Alias for kitchen:all'
+task integration: 'kitchen:all'
+
+task default: %i[spec make_bin_executable yard rubocop check_binstubs integration]
+task quick: %i[make_bin_executable yard rubocop check_binstubs]

--- a/bin/check-postgres-alive.rb
+++ b/bin/check-postgres-alive.rb
@@ -27,10 +27,17 @@
 #   for details.
 #
 
+require 'sensu-plugins-postgres/pgpass'
 require 'sensu-plugin/check/cli'
 require 'pg'
 
 class CheckPostgres < Sensu::Plugin::Check::CLI
+  option :pgpass,
+         description: 'Pgpass file',
+         short: '-f FILE',
+         long: '--pgpass',
+         default: ENV['PGPASSFILE'] || "#{ENV['HOME']}/.pgpass"
+
   option :user,
          description: 'Postgres User',
          short: '-u USER',
@@ -49,14 +56,12 @@ class CheckPostgres < Sensu::Plugin::Check::CLI
   option :database,
          description: 'Database schema to connect to',
          short: '-d DATABASE',
-         long: '--database DATABASE',
-         default: 'test'
+         long: '--database DATABASE'
 
   option :port,
          description: 'Database port',
          short: '-P PORT',
-         long: '--port PORT',
-         default: 5432
+         long: '--port PORT'
 
   option :timeout,
          description: 'Connection timeout (seconds)',
@@ -64,11 +69,15 @@ class CheckPostgres < Sensu::Plugin::Check::CLI
          long: '--timeout TIMEOUT',
          default: nil
 
+  include Pgpass
+
   def run
+    pgpass
     con = PG.connect(host: config[:hostname],
                      dbname: config[:database],
                      user: config[:user],
                      password: config[:password],
+                     port: config[:port],
                      connect_timeout: config[:timeout])
     res = con.exec('select version();')
     info = res.first

--- a/bin/check-postgres-query.rb
+++ b/bin/check-postgres-query.rb
@@ -29,12 +29,19 @@
 #   for details.
 #
 
+require 'sensu-plugins-postgres/pgpass'
 require 'sensu-plugin/check/cli'
 require 'pg'
 require 'dentaku'
 
 # Check PostgresSQL Query
 class CheckPostgresQuery < Sensu::Plugin::Check::CLI
+  option :pgpass,
+         description: 'Pgpass file',
+         short: '-f FILE',
+         long: '--pgpass',
+         default: ENV['PGPASSFILE'] || "#{ENV['HOME']}/.pgpass"
+
   option :user,
          description: 'Postgres User',
          short: '-u USER',
@@ -48,20 +55,17 @@ class CheckPostgresQuery < Sensu::Plugin::Check::CLI
   option :hostname,
          description: 'Hostname to login to',
          short: '-h HOST',
-         long: '--hostname HOST',
-         default: 'localhost'
+         long: '--hostname HOST'
 
   option :port,
          description: 'Database port',
          short: '-P PORT',
-         long: '--port PORT',
-         default: 5432
+         long: '--port PORT'
 
   option :database,
          description: 'Database name',
          short: '-d DB',
-         long: '--db DB',
-         default: 'postgres'
+         long: '--db DB'
 
   option :query,
          description: 'Database query to execute',
@@ -94,12 +98,16 @@ class CheckPostgresQuery < Sensu::Plugin::Check::CLI
          long: '--timeout TIMEOUT',
          default: nil
 
+  include Pgpass
+
   def run
     begin
+      pgpass
       con = PG.connect(host: config[:hostname],
                        dbname: config[:database],
                        user: config[:user],
                        password: config[:password],
+                       port: config[:port],
                        connect_timeout: config[:timeout])
       res = con.exec(config[:query].to_s)
     rescue PG::Error => e

--- a/bin/check-postgres-replication.rb
+++ b/bin/check-postgres-replication.rb
@@ -92,7 +92,7 @@ class CheckPostgresReplicationStatus < Sensu::Plugin::Check::CLI
 
   option(:timeout,
          short: '-T',
-         long: '--timeout',
+         long: '--timeout TIMEOUT',
          default: nil,
          description: 'Connection timeout (seconds)')
 

--- a/bin/check-postgres-replication.rb
+++ b/bin/check-postgres-replication.rb
@@ -140,7 +140,7 @@ class CheckPostgresReplicationStatus < Sensu::Plugin::Check::CLI
                             connect_timeout: config[:timeout])
 
     slave = if check_vsn(conn_slave)
-              conn_slave.exec('SELECT pg_last_xlog_receive_location()').getvalue(0, 0)
+              conn_slave.exec('SELECT pg_last_xlog_replay_location()').getvalue(0, 0)
             else
               conn_slave.exec('SELECT pg_last_wal_replay_lsn()').getvalue(0, 0)
             end

--- a/bin/check-postgres-replication.rb
+++ b/bin/check-postgres-replication.rb
@@ -17,7 +17,7 @@
 #   gem: pg
 #
 # USAGE:
-#   ./check-postgres-replication.rb -m master_host -s slave_host -d db -u db_user -p db_pass -w warn_threshold -c crit_threshold
+#   ./check-postgres-replication.rb -m master_host -s slave_host -P port -d db -u db_user -p db_pass -w warn_threshold -c crit_threshold
 #
 # NOTES:
 #
@@ -26,10 +26,17 @@
 #   for details.
 #
 
+require 'sensu-plugins-postgres/pgpass'
 require 'sensu-plugin/check/cli'
 require 'pg'
 
 class CheckPostgresReplicationStatus < Sensu::Plugin::Check::CLI
+  option :pgpass,
+         description: 'Pgpass file',
+         short: '-f FILE',
+         long: '--pgpass',
+         default: ENV['PGPASSFILE'] || "#{ENV['HOME']}/.pgpass"
+
   option(:master_host,
          short: '-m',
          long: '--master-host=HOST',
@@ -40,6 +47,11 @@ class CheckPostgresReplicationStatus < Sensu::Plugin::Check::CLI
          long: '--slave-host=HOST',
          description: 'PostgreSQL slave HOST',
          default: 'localhost')
+
+  option(:port,
+         short: '-P',
+         long: '--port=PORT',
+         description: 'PostgreSQL port')
 
   option(:database,
          short: '-d',
@@ -80,9 +92,11 @@ class CheckPostgresReplicationStatus < Sensu::Plugin::Check::CLI
 
   option(:timeout,
          short: '-T',
-         long: '--timeout TIMEOUT',
+         long: '--timeout',
          default: nil,
          description: 'Connection timeout (seconds)')
+
+  include Pgpass
 
   def compute_lag(master, slave, m_segbytes)
     m_segment, m_offset = master.split('/')
@@ -90,18 +104,29 @@ class CheckPostgresReplicationStatus < Sensu::Plugin::Check::CLI
     ((m_segment.hex - s_segment.hex) * m_segbytes) + (m_offset.hex - s_offset.hex)
   end
 
+  def check_vsn(conn)
+    pg_vsn = conn.exec("SELECT current_setting('server_version')").getvalue(0, 0)
+    Gem::Version.new(pg_vsn) < Gem::Version.new('10.0') && Gem::Version.new(pg_vsn) >= Gem::Version.new('9.0')
+  end
+
   def run
     ssl_mode = config[:ssl] ? 'require' : 'prefer'
 
     # Establishing connection to the master
+    pgpass
     conn_master = PG.connect(host: config[:master_host],
                              dbname: config[:database],
                              user: config[:user],
                              password: config[:password],
+                             port: config[:port],
                              sslmode: ssl_mode,
                              connect_timeout: config[:timeout])
 
-    master = conn_master.exec('SELECT pg_current_xlog_location()').getvalue(0, 0)
+    master = if check_vsn(conn_master)
+               conn_master.exec('SELECT pg_current_xlog_location()').getvalue(0, 0)
+             else
+               conn_master.exec('SELECT pg_current_wal_lsn()').getvalue(0, 0)
+             end
     m_segbytes = conn_master.exec('SHOW wal_segment_size').getvalue(0, 0).sub(/\D+/, '').to_i << 20
     conn_master.close
 
@@ -110,10 +135,15 @@ class CheckPostgresReplicationStatus < Sensu::Plugin::Check::CLI
                             dbname: config[:database],
                             user: config[:user],
                             password: config[:password],
+                            port: config[:port],
                             sslmode: ssl_mode,
                             connect_timeout: config[:timeout])
 
-    slave = conn_slave.exec('SELECT pg_last_xlog_replay_location()').getvalue(0, 0)
+    slave = if check_vsn(conn_slave)
+              conn_slave.exec('SELECT pg_last_xlog_receive_location()').getvalue(0, 0)
+            else
+              conn_slave.exec('SELECT pg_last_wal_replay_lsn()').getvalue(0, 0)
+            end
     conn_slave.close
 
     # Computing lag

--- a/bin/metric-postgres-connections.rb
+++ b/bin/metric-postgres-connections.rb
@@ -28,11 +28,18 @@
 #   for details.
 #
 
+require 'sensu-plugins-postgres/pgpass'
 require 'sensu-plugin/metric/cli'
 require 'pg'
 require 'socket'
 
 class PostgresStatsDBMetrics < Sensu::Plugin::Metric::CLI::Graphite
+  option :pgpass,
+         description: 'Pgpass file',
+         short: '-f FILE',
+         long: '--pgpass',
+         default: "#{ENV['HOME']}/.pgpass"
+
   option :user,
          description: 'Postgres User',
          short: '-u USER',
@@ -46,20 +53,17 @@ class PostgresStatsDBMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :hostname,
          description: 'Hostname to login to',
          short: '-h HOST',
-         long: '--hostname HOST',
-         default: 'localhost'
+         long: '--hostname HOST'
 
   option :port,
          description: 'Database port',
          short: '-P PORT',
-         long: '--port PORT',
-         default: 5432
+         long: '--port PORT'
 
   option :database,
          description: 'Database name',
          short: '-d DB',
-         long: '--db DB',
-         default: 'postgres'
+         long: '--db DB'
 
   option :scheme,
          description: 'Metric naming scheme, text to prepend to $queue_name.$metric',
@@ -72,13 +76,16 @@ class PostgresStatsDBMetrics < Sensu::Plugin::Metric::CLI::Graphite
          long: '--timeout TIMEOUT',
          default: nil
 
+  include Pgpass
+
   def run
     timestamp = Time.now.to_i
-
+    pgpass
     con     = PG.connect(host: config[:hostname],
                          dbname: config[:database],
                          user: config[:user],
                          password: config[:password],
+                         port: config[:port],
                          connect_timeout: config[:timeout])
     request = [
       "select case when count(*) = 1 then 'waiting' else",

--- a/bin/metric-postgres-dbsize.rb
+++ b/bin/metric-postgres-dbsize.rb
@@ -28,11 +28,18 @@
 #   for details.
 #
 
+require 'sensu-plugins-postgres/pgpass'
 require 'sensu-plugin/metric/cli'
 require 'pg'
 require 'socket'
 
 class PostgresStatsDBMetrics < Sensu::Plugin::Metric::CLI::Graphite
+  option :pgpass,
+         description: 'Pgpass file',
+         short: '-f FILE',
+         long: '--pgpass',
+         default: ENV['PGPASSFILE'] || "#{ENV['HOME']}/.pgpass"
+
   option :user,
          description: 'Postgres User',
          short: '-u USER',
@@ -46,20 +53,17 @@ class PostgresStatsDBMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :hostname,
          description: 'Hostname to login to',
          short: '-h HOST',
-         long: '--hostname HOST',
-         default: 'localhost'
+         long: '--hostname HOST'
 
   option :port,
          description: 'Database port',
          short: '-P PORT',
-         long: '--port PORT',
-         default: 5432
+         long: '--port PORT'
 
   option :database,
          description: 'Database name',
          short: '-d DB',
-         long: '--db DB',
-         default: 'postgres'
+         long: '--db DB'
 
   option :scheme,
          description: 'Metric naming scheme, text to prepend to $queue_name.$metric',
@@ -72,13 +76,16 @@ class PostgresStatsDBMetrics < Sensu::Plugin::Metric::CLI::Graphite
          long: '--timeout TIMEOUT',
          default: nil
 
+  include Pgpass
+
   def run
     timestamp = Time.now.to_i
-
+    pgpass
     con     = PG.connect(host: config[:hostname],
                          dbname: config[:database],
                          user: config[:user],
                          password: config[:password],
+                         port: config[:port],
                          connect_timeout: config[:timeout])
     request = [
       "select pg_database_size('#{config[:database]}')"

--- a/bin/metric-postgres-graphite.rb
+++ b/bin/metric-postgres-graphite.rb
@@ -26,11 +26,18 @@
 #   for details.
 #
 
+require 'sensu-plugins-postgres/pgpass'
 require 'pg'
 require 'sensu-plugin/metric/cli'
 require 'socket'
 
 class CheckpostgresReplicationStatus < Sensu::Plugin::Metric::CLI::Graphite
+  option :pgpass,
+         description: 'Pgpass file',
+         short: '-f FILE',
+         long: '--pgpass',
+         default: ENV['PGPASSFILE'] || "#{ENV['HOME']}/.pgpass"
+
   option :master_host,
          short: '-m',
          long: '--master=HOST',
@@ -45,15 +52,14 @@ class CheckpostgresReplicationStatus < Sensu::Plugin::Metric::CLI::Graphite
   option :database,
          short: '-d',
          long: '--database=NAME',
-         description: 'Database NAME',
-         default: 'postgres'
+         description: 'Database NAME'
 
   option :user,
          short: '-u',
          long: '--username=VALUE',
          description: 'Database username'
 
-  option :pass,
+  option :password,
          short: '-p',
          long: '--password=VALUE',
          description: 'Database password'
@@ -67,8 +73,7 @@ class CheckpostgresReplicationStatus < Sensu::Plugin::Metric::CLI::Graphite
   option :port,
          description: 'Database port',
          short: '-P PORT',
-         long: '--port PORT',
-         default: 5432
+         long: '--port PORT'
 
   option :timeout,
          description: 'Connection timeout (seconds)',
@@ -76,12 +81,16 @@ class CheckpostgresReplicationStatus < Sensu::Plugin::Metric::CLI::Graphite
          long: '--timeout TIMEOUT',
          default: nil
 
+  include Pgpass
+
   def run
     # Establishing connections to the master
+    pgpass
     conn_master = PG.connect(host: config[:master_host],
                              dbname: config[:database],
                              user: config[:user],
                              password: config[:password],
+                             port: config[:port],
                              connect_timeout: config[:timeout])
     res1 = conn_master.exec('SELECT pg_current_xlog_location()').getvalue(0, 0)
     m_segbytes = conn_master.exec('SHOW wal_segment_size').getvalue(0, 0).sub(/\D+/, '').to_i << 20
@@ -98,8 +107,9 @@ class CheckpostgresReplicationStatus < Sensu::Plugin::Metric::CLI::Graphite
                             dbname: config[:database],
                             user: config[:user],
                             password: config[:password],
+                            port: config[:port],
                             connect_timeout: config[:timeout])
-    res = conn_slave.exec('SELECT pg_last_xlog_replay_location()').getvalue(0, 0)
+    res = conn_slave.exec('SELECT pg_last_xlog_receive_location()').getvalue(0, 0)
     conn_slave.close
 
     # Compute lag

--- a/bin/metric-postgres-graphite.rb
+++ b/bin/metric-postgres-graphite.rb
@@ -109,7 +109,7 @@ class CheckpostgresReplicationStatus < Sensu::Plugin::Metric::CLI::Graphite
                             password: config[:password],
                             port: config[:port],
                             connect_timeout: config[:timeout])
-    res = conn_slave.exec('SELECT pg_last_xlog_receive_location()').getvalue(0, 0)
+    res = conn_slave.exec('SELECT pg_last_xlog_replay_location()').getvalue(0, 0)
     conn_slave.close
 
     # Compute lag

--- a/bin/metric-postgres-locks.rb
+++ b/bin/metric-postgres-locks.rb
@@ -28,11 +28,18 @@
 #   for details.
 #
 
+require 'sensu-plugins-postgres/pgpass'
 require 'sensu-plugin/metric/cli'
 require 'pg'
 require 'socket'
 
 class PostgresStatsDBMetrics < Sensu::Plugin::Metric::CLI::Graphite
+  option :pgpass,
+         description: 'Pgpass file',
+         short: '-f FILE',
+         long: '--pgpass',
+         default: ENV['PGPASSFILE'] || "#{ENV['HOME']}/.pgpass"
+
   option :user,
          description: 'Postgres User',
          short: '-u USER',
@@ -46,20 +53,17 @@ class PostgresStatsDBMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :hostname,
          description: 'Hostname to login to',
          short: '-h HOST',
-         long: '--hostname HOST',
-         default: 'localhost'
+         long: '--hostname HOST'
 
   option :port,
          description: 'Database port',
          short: '-P PORT',
-         long: '--port PORT',
-         default: 5432
+         long: '--port PORT'
 
   option :database,
          description: 'Database name',
          short: '-d DB',
-         long: '--db DB',
-         default: 'postgres'
+         long: '--db DB'
 
   option :scheme,
          description: 'Metric naming scheme, text to prepend to $queue_name.$metric',
@@ -72,26 +76,29 @@ class PostgresStatsDBMetrics < Sensu::Plugin::Metric::CLI::Graphite
          long: '--timeout TIMEOUT',
          default: nil
 
+  include Pgpass
+
   def run
     timestamp = Time.now.to_i
 
     locks_per_type = Hash.new(0)
-
+    pgpass
     con     = PG.connect(host: config[:hostname],
                          dbname: config[:database],
                          user: config[:user],
                          password: config[:password],
+                         port: config[:port],
                          connect_timeout: config[:timeout])
     request = [
-      'SELECT mode, count(mode) FROM pg_locks',
-      "where database = (select oid from pg_database where datname = '#{config[:database]}')",
-      'group by mode'
+      'SELECT mode, count(mode) AS count FROM pg_locks',
+      "WHERE database = (SELECT oid FROM pg_database WHERE datname = '#{config[:database]}')",
+      'GROUP BY mode'
     ]
 
     con.exec(request.join(' ')) do |result|
       result.each do |row|
         lock_name = row['mode'].downcase.to_sym
-        locks_per_type[lock_name] += 1
+        locks_per_type[lock_name] = row['count']
       end
     end
 

--- a/bin/metric-postgres-statsbgwriter.rb
+++ b/bin/metric-postgres-statsbgwriter.rb
@@ -28,11 +28,18 @@
 #   for details.
 #
 
+require 'sensu-plugins-postgres/pgpass'
 require 'sensu-plugin/metric/cli'
 require 'pg'
 require 'socket'
 
 class PostgresStatsDBMetrics < Sensu::Plugin::Metric::CLI::Graphite
+  option :pgpass,
+         description: 'Pgpass file',
+         short: '-f FILE',
+         long: '--pgpass',
+         default: ENV['PGPASSFILE'] || "#{ENV['HOME']}/.pgpass"
+
   option :user,
          description: 'Postgres User',
          short: '-u USER',
@@ -46,14 +53,12 @@ class PostgresStatsDBMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :hostname,
          description: 'Hostname to login to',
          short: '-h HOST',
-         long: '--hostname HOST',
-         default: 'localhost'
+         long: '--hostname HOST'
 
   option :port,
          description: 'Database port',
          short: '-P PORT',
-         long: '--port PORT',
-         default: 5432
+         long: '--port PORT'
 
   option :scheme,
          description: 'Metric naming scheme, text to prepend to $queue_name.$metric',
@@ -66,13 +71,16 @@ class PostgresStatsDBMetrics < Sensu::Plugin::Metric::CLI::Graphite
          long: '--timeout TIMEOUT',
          default: nil
 
+  include Pgpass
+
   def run
     timestamp = Time.now.to_i
-
+    pgpass
     con     = PG.connect(host: config[:hostname],
                          dbname: 'postgres',
                          user: config[:user],
                          password: config[:password],
+                         port: config[:port],
                          connect_timeout: config[:timeout])
     request = [
       'select checkpoints_timed, checkpoints_req,',

--- a/bin/metric-postgres-statsdb.rb
+++ b/bin/metric-postgres-statsdb.rb
@@ -29,11 +29,18 @@
 #   for details.
 #
 
+require 'sensu-plugins-postgres/pgpass'
 require 'sensu-plugin/metric/cli'
 require 'pg'
 require 'socket'
 
 class PostgresStatsDBMetrics < Sensu::Plugin::Metric::CLI::Graphite
+  option :pgpass,
+         description: 'Pgpass file',
+         short: '-f FILE',
+         long: '--pgpass',
+         default: ENV['PGPASSFILE'] || "#{ENV['HOME']}/.pgpass"
+
   option :user,
          description: 'Postgres User',
          short: '-u USER',
@@ -47,20 +54,17 @@ class PostgresStatsDBMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :hostname,
          description: 'Hostname to login to',
          short: '-h HOST',
-         long: '--hostname HOST',
-         default: 'localhost'
+         long: '--hostname HOST'
 
   option :port,
          description: 'Database port',
          short: '-P PORT',
-         long: '--port PORT',
-         default: 5432
+         long: '--port PORT'
 
   option :database,
          description: 'Database name',
          short: '-d DB',
-         long: '--db DB',
-         default: 'postgres'
+         long: '--db DB'
 
   option :scheme,
          description: 'Metric naming scheme, text to prepend to $queue_name.$metric',
@@ -73,22 +77,26 @@ class PostgresStatsDBMetrics < Sensu::Plugin::Metric::CLI::Graphite
          long: '--timeout TIMEOUT',
          default: nil
 
+  include Pgpass
+
   def run
     timestamp = Time.now.to_i
-
+    pgpass
     con     = PG.connect(host: config[:hostname],
                          dbname: config[:database],
                          user: config[:user],
                          password: config[:password],
+                         port: config[:port],
                          connect_timeout: config[:timeout])
     request = [
-      'select xact_commit, xact_rollback,',
+      'select numbackends, xact_commit, xact_rollback,',
       'blks_read, blks_hit,',
       'tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted',
       "from pg_stat_database where datname='#{config[:database]}'"
     ]
     con.exec(request.join(' ')) do |result|
       result.each do |row|
+        output "#{config[:scheme]}.statsdb.#{config[:database]}.numbackends", row['numbackends'], timestamp
         output "#{config[:scheme]}.statsdb.#{config[:database]}.xact_commit", row['xact_commit'], timestamp
         output "#{config[:scheme]}.statsdb.#{config[:database]}.xact_rollback", row['xact_rollback'], timestamp
         output "#{config[:scheme]}.statsdb.#{config[:database]}.blks_read", row['blks_read'], timestamp

--- a/bin/metric-postgres-statsio.rb
+++ b/bin/metric-postgres-statsio.rb
@@ -29,11 +29,18 @@
 #   for details.
 #
 
+require 'sensu-plugins-postgres/pgpass'
 require 'sensu-plugin/metric/cli'
 require 'pg'
 require 'socket'
 
 class PostgresStatsIOMetrics < Sensu::Plugin::Metric::CLI::Graphite
+  option :pgpass,
+         description: 'Pgpass file',
+         short: '-f FILE',
+         long: '--pgpass',
+         default: ENV['PGPASSFILE'] || "#{ENV['HOME']}/.pgpass"
+
   option :user,
          description: 'Postgres User',
          short: '-u USER',
@@ -47,20 +54,17 @@ class PostgresStatsIOMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :hostname,
          description: 'Hostname to login to',
          short: '-h HOST',
-         long: '--hostname HOST',
-         default: 'localhost'
+         long: '--hostname HOST'
 
   option :port,
          description: 'Database port',
          short: '-P PORT',
-         long: '--port PORT',
-         default: 5432
+         long: '--port PORT'
 
   option :database,
          description: 'Database name',
          short: '-d DB',
-         long: '--db DB',
-         default: 'postgres'
+         long: '--db DB'
 
   option :scope,
          description: 'Scope, see http://www.postgresql.org/docs/9.2/static/monitoring-stats.html',
@@ -79,13 +83,16 @@ class PostgresStatsIOMetrics < Sensu::Plugin::Metric::CLI::Graphite
          long: '--timeout TIMEOUT',
          default: nil
 
+  include Pgpass
+
   def run
     timestamp = Time.now.to_i
-
+    pgpass
     con     = PG.connect(host: config[:hostname],
                          dbname: config[:database],
                          user: config[:user],
                          password: config[:password],
+                         port: config[:port],
                          connect_timeout: config[:timeout])
     request = [
       'select sum(heap_blks_read) as heap_blks_read, sum(heap_blks_hit) as heap_blks_hit,',

--- a/bin/metric-postgres-statstable.rb
+++ b/bin/metric-postgres-statstable.rb
@@ -29,11 +29,18 @@
 #   for details.
 #
 
+require 'sensu-plugins-postgres/pgpass'
 require 'sensu-plugin/metric/cli'
 require 'pg'
 require 'socket'
 
 class PostgresStatsTableMetrics < Sensu::Plugin::Metric::CLI::Graphite
+  option :pgpass,
+         description: 'Pgpass file',
+         short: '-f FILE',
+         long: '--pgpass',
+         default: ENV['PGPASSFILE'] || "#{ENV['HOME']}/.pgpass"
+
   option :user,
          description: 'Postgres User',
          short: '-u USER',
@@ -47,20 +54,17 @@ class PostgresStatsTableMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :hostname,
          description: 'Hostname to login to',
          short: '-h HOST',
-         long: '--hostname HOST',
-         default: 'localhost'
+         long: '--hostname HOST'
 
   option :port,
          description: 'Database port',
          short: '-P PORT',
-         long: '--port PORT',
-         default: 5432
+         long: '--port PORT'
 
   option :database,
          description: 'Database name',
          short: '-d DB',
-         long: '--db DB',
-         default: 'postgres'
+         long: '--db DB'
 
   option :scope,
          description: 'Scope, see http://www.postgresql.org/docs/9.2/static/monitoring-stats.html',
@@ -79,13 +83,16 @@ class PostgresStatsTableMetrics < Sensu::Plugin::Metric::CLI::Graphite
          long: '--timeout TIMEOUT',
          default: nil
 
+  include Pgpass
+
   def run
     timestamp = Time.now.to_i
-
+    pgpass
     con     = PG.connect(host: config[:hostname],
                          dbname: config[:database],
                          user: config[:user],
                          password: config[:password],
+                         port: config[:port],
                          connect_timeout: config[:timeout])
     request = [
       'select sum(seq_scan) as seq_scan, sum(seq_tup_read) as seq_tup_read,',

--- a/lib/sensu-plugins-postgres.rb
+++ b/lib/sensu-plugins-postgres.rb
@@ -1,1 +1,2 @@
 require 'sensu-plugins-postgres/version'
+require 'sensu-plugins-postgres/pgpass'

--- a/lib/sensu-plugins-postgres/pgpass.rb
+++ b/lib/sensu-plugins-postgres/pgpass.rb
@@ -1,0 +1,17 @@
+module Pgpass
+  def pgpass
+    if File.file?(config[:pgpass])
+      pgpass = Hash[%i[hostname port database user password].zip(File.readlines(config[:pgpass])[0].strip.split(':'))]
+      pgpass[:database] = nil if pgpass[:database] == '*'
+      pgpass.each do |k, v|
+        config[k] ||= v
+      end
+    else
+      config[:hostname] ||= ENV['PGHOST']     || 'localhost'
+      config[:port]     ||= ENV['PGPORT']     || 5432
+      config[:database] ||= ENV['PGDATABASE'] || 'postgres'
+      config[:user]     ||= ENV['PGUSER']     || 'postgres'
+      config[:password] ||= ENV['PGPASSWORD']
+    end
+  end
+end

--- a/lib/sensu-plugins-postgres/version.rb
+++ b/lib/sensu-plugins-postgres/version.rb
@@ -1,8 +1,8 @@
 module SensuPluginsPostgres
   module Version
     MAJOR = 1
-    MINOR = 0
-    PATCH = 1
+    MINOR = 4
+    PATCH = 5
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end

--- a/lib/sensu-plugins-postgres/version.rb
+++ b/lib/sensu-plugins-postgres/version.rb
@@ -2,7 +2,7 @@ module SensuPluginsPostgres
   module Version
     MAJOR = 1
     MINOR = 4
-    PATCH = 5
+    PATCH = 8
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end

--- a/sensu-plugins-postgres.gemspec
+++ b/sensu-plugins-postgres.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'date'
 require_relative 'lib/sensu-plugins-postgres'
 
-Gem::Specification.new do |s|
+Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.authors                = ['Sensu-Plugins and contributors']
 
   s.date                   = Date.today.to_s
@@ -16,10 +16,10 @@ Gem::Specification.new do |s|
                               more.'
   s.email                  = '<sensu-users@googlegroups.com>'
   s.executables            = Dir.glob('bin/**/*.rb').map { |file| File.basename(file) }
-  s.files                  = Dir.glob('{bin,lib}/**/*') + %w(LICENSE README.md CHANGELOG.md)
+  s.files                  = Dir.glob('{bin,lib}/**/*') + %w[LICENSE README.md CHANGELOG.md]
   s.homepage               = 'https://github.com/sensu-plugins/sensu-plugins-postgres'
   s.license                = 'MIT'
-  s.metadata               = { 'maintainer'         => '@tas50',
+  s.metadata               = { 'maintainer'         => 'sensu-plugin',
                                'development_status' => 'active',
                                'production_status'  => 'unstable - testing recommended',
                                'release_draft'      => 'false',
@@ -35,16 +35,23 @@ Gem::Specification.new do |s|
   s.version                = SensuPluginsPostgres::Version::VER_STRING
 
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
-  s.add_runtime_dependency 'pg',           '0.18.3'
+
   s.add_runtime_dependency 'dentaku',      '2.0.4'
+  s.add_runtime_dependency 'pg',           '0.18.3'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'
   s.add_development_dependency 'github-markup',             '~> 1.3'
+  s.add_development_dependency 'kitchen-docker',            '~> 2.6'
+  s.add_development_dependency 'kitchen-localhost',         '~> 0.3'
+  # locked to keep ruby 2.1 support, this is pulled in by test-kitchen
+  s.add_development_dependency 'mixlib-shellout',           ['< 2.3.0', '~> 2.2']
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 10.0'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
   s.add_development_dependency 'rspec',                     '~> 3.1'
-  s.add_development_dependency 'rubocop',                   '~> 0.40.0'
+  s.add_development_dependency 'rubocop',                   '~> 0.49.0'
+  s.add_development_dependency 'serverspec',                '~> 2.36.1'
+  s.add_development_dependency 'test-kitchen',              '~> 1.16.0'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end

--- a/test/fixtures/bootstrap.sh
+++ b/test/fixtures/bootstrap.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Set up a super simple web server and make it accept GET and POST requests
+# for Sensu plugin testing.
+#
+
+set -e
+
+# base utilities that need to exist to start bootatraping
+apt-get update
+apt-get install -y wget
+
+# setup the rubies
+source /etc/profile
+DATA_DIR=/tmp/kitchen/data
+RUBY_HOME=${MY_RUBY_HOME}
+
+# Start bootatraping
+
+## install some required deps for pg_gem to install
+apt-get install -y libpq-dev build-essential
+
+# setup postgres server
+## TODO: multiple postgres versions and replication the versions should probably
+## be matrixed but wanted to start as small as possible initially.
+
+
+# End of Actual bootatrap
+
+# Install gems
+cd $DATA_DIR
+SIGN_GEM=false gem build sensu-plugins-postgres.gemspec
+gem install sensu-plugins-postgres-*.gem

--- a/test/integration/helpers/serverspec/check-postgres-alive-shared_spec.rb
+++ b/test/integration/helpers/serverspec/check-postgres-alive-shared_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'shared_spec'
+
+gem_path = '/usr/local/bin'
+check_name = 'check-postgres-alive.rb'
+check = "#{gem_path}/#{check_name}"
+pg_user = 'postgres'
+pg_password = '<REDACTED>'
+# TODO: fix up the hostname to be pulled in via the suite based on the version being tested
+pg_host = 'sensu-postgres-10'
+
+describe 'ruby environment' do
+  it_behaves_like 'ruby checks', check
+end
+
+# NOTE: This ia a TERRIBLE idea and you should never specify a cleartext
+# password on the cli like this. you should use the pgpass or sensu tokens:
+# https://sensuapp.org/docs/1.1/reference/checks.html#check-token-substitution
+# do not use this method for anything but testing.
+describe command("#{check} --user #{pg_user} --password \'#{pg_password}\' --hostname #{pg_host}") do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match(/CheckPostgres OK: Server version: {"version"=>"PostgreSQL/) }
+end

--- a/test/integration/helpers/serverspec/shared_spec.rb
+++ b/test/integration/helpers/serverspec/shared_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+shared_examples_for 'ruby checks' do |check|
+  describe command('which ruby') do
+    its(:exit_status) { should eq 0 }
+    its(:stdout) { should match(/\/usr\/local\/bin\/ruby/) }
+  end
+
+  describe command('which gem') do
+    its(:exit_status) { should eq 0 }
+    its(:stdout) { should match(/\/usr\/local\/bin\/gem/) }
+  end
+
+  describe command("which #{check}") do
+    its(:exit_status) { should eq 0 }
+    its(:stdout) { should match(Regexp.new(Regexp.escape(check))) }
+  end
+
+  describe file(check) do
+    it { should be_file }
+    it { should be_executable }
+  end
+end

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require 'serverspec'
+
+set :backend, :exec

--- a/test/integration/ruby-21/serverspec/default_spec.rb
+++ b/test/integration/ruby-21/serverspec/default_spec.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'shared_spec'

--- a/test/integration/ruby-22/serverspec/default_spec.rb
+++ b/test/integration/ruby-22/serverspec/default_spec.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'shared_spec'

--- a/test/integration/ruby-230/serverspec/default_spec.rb
+++ b/test/integration/ruby-230/serverspec/default_spec.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'shared_spec'

--- a/test/integration/ruby-241/serverspec/default_spec.rb
+++ b/test/integration/ruby-241/serverspec/default_spec.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'shared_spec'

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -1,2 +1,9 @@
+# frozen_string_literal: true
+
 require 'codeclimate-test-reporter'
 CodeClimate::TestReporter.start
+
+RSpec.configure do |c|
+  c.formatter = :documentation
+  c.color = true
+end


### PR DESCRIPTION
## Description

To handle pg 9.X and pg 10, we need to gather the latest `sensu-plugins-postgres` release published on the [upstream repo](https://github.com/lemonde/sensu-plugins-postgres) we forked.
Then add again the few fixes committed in the past in our fork.

**=> => So, no need to review the first big commit in the current PR.**